### PR TITLE
fixed view path in hello controller

### DIFF
--- a/lib/hello/controllers/hello.js
+++ b/lib/hello/controllers/hello.js
@@ -11,7 +11,7 @@ exports.sayHello = function(req, res) {
   , welcomeMessage: greeter.welcomeMessage(name)
   };
 
-  var template = '../lib/hello/views/hello';
+  var template = __dirname + '/../views/hello';
   res.render(template, context);
 
   // More elaborate res.render() format:


### PR DESCRIPTION
There are a two bugs that I have found in nodebootstrap which occur only when you run `./bin/start.sh` (and not `./bin/dev_start.sh`, one of them is this. The view path that was set in `lib/hello/controllers/hello.js`, line 14 was working fine in development (though I have no idea why), but was giving an internal server error (related to the view path) in production. I just changed the path to what it should be relative to the file where it is being set, and     view started rendering (minus the layout though)